### PR TITLE
Add jQuery as a dependency

### DIFF
--- a/inc/BeaverBuilder.php
+++ b/inc/BeaverBuilder.php
@@ -47,7 +47,7 @@ class BeaverBuilder {
         // Check if Beaver Builder is active 
         if ( class_exists('FLBuilderModel') && \FLBuilderModel::is_builder_active() ) {
     
-           wp_enqueue_script('bb-ui-enhancements', BBUIENHANCEMENTS_URL . 'js/bb-ui-enhancements.js', null, BBUIENHANCEMENTS_VERSION , true );
+           wp_enqueue_script('bb-ui-enhancements', BBUIENHANCEMENTS_URL . 'js/bb-ui-enhancements.js', array( 'query' ), BBUIENHANCEMENTS_VERSION );
 
            $enhancement_settings = apply_filters( 'bb-ui-enhancements-settings' , array( 'pluginFolder' => BBUIENHANCEMENTS_URL , 'enhanceButton' => true  , 'xray' => false ) );
 

--- a/inc/BeaverBuilder.php
+++ b/inc/BeaverBuilder.php
@@ -47,7 +47,7 @@ class BeaverBuilder {
         // Check if Beaver Builder is active 
         if ( class_exists('FLBuilderModel') && \FLBuilderModel::is_builder_active() ) {
     
-           wp_enqueue_script('bb-ui-enhancements', BBUIENHANCEMENTS_URL . 'js/bb-ui-enhancements.js', array( 'query' ), BBUIENHANCEMENTS_VERSION );
+           wp_enqueue_script('bb-ui-enhancements', BBUIENHANCEMENTS_URL . 'js/bb-ui-enhancements.js', array( 'jquery' ), BBUIENHANCEMENTS_VERSION );
 
            $enhancement_settings = apply_filters( 'bb-ui-enhancements-settings' , array( 'pluginFolder' => BBUIENHANCEMENTS_URL , 'enhanceButton' => true  , 'xray' => false ) );
 


### PR DESCRIPTION
Forcing to the footer is not a sure way to make sure it loads after jQuery especially when most people force jquery to the footer to get extra internet points on their 1st day on the job ;) Adding jQuery as a dependency ensures the script loads after it no matter where jQuery is added.